### PR TITLE
fix: store gpg key not `/etc/apt/trusted.gpg` but `/etc/apt/keyrings/<name>.gpg`

### DIFF
--- a/playbooks/azurecli.yml
+++ b/playbooks/azurecli.yml
@@ -12,12 +12,13 @@
     - name: "Add apt key"
       apt_key:
         url: https://packages.microsoft.com/keys/microsoft.asc
+        keyring: /etc/apt/keyrings/microsoft.gpg
     - name: "Get \"lsb_release -cs\""
       shell: "lsb_release -cs"
       register: lsb_release
     - name: "Add repository"
       apt_repository:
-        repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ {{ lsb_release.stdout }} main"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ {{ lsb_release.stdout }} main"
     - name: "Install azurecli"
       apt:
         name: azure-cli

--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -8,12 +8,13 @@
     - name: "Add apt key"
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
+        keyring: /etc/apt/keyrings/docker.gpg
     - name: "Get \"lsb_release -cs\""
       shell: "lsb_release -cs"
       register: lsb_release
     - name: "Add repository"
       apt_repository:
-        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ lsb_release.stdout }} stable"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ lsb_release.stdout }} stable"
     - name: "Install docker"
       apt:
         name: docker-ce

--- a/playbooks/powershell.yml
+++ b/playbooks/powershell.yml
@@ -8,6 +8,7 @@
     - name: "Add apt key"
       apt_key:
         url: https://packages.microsoft.com/keys/microsoft.asc
+        keyring: /etc/apt/keyrings/microsoft.gpg
     - name: "Get \"lsb_release -cs\""
       shell: "lsb_release -cs"
       register: lsb_release_c
@@ -16,7 +17,7 @@
       register: lsb_release_r
     - name: "Add repository"
       apt_repository:
-        repo: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ lsb_release_r.stdout }}/prod {{ lsb_release_c.stdout }} main"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/{{ lsb_release_r.stdout }}/prod {{ lsb_release_c.stdout }} main"
     - name: "Install powershell"
       apt:
         name: powershell


### PR DESCRIPTION
To fix following warning.

```
W: https://download.docker.com/linux/ubuntu/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```